### PR TITLE
Seperate cache for apt index files and shorten its valid time

### DIFF
--- a/extras/etc/nginx/nginx.conf
+++ b/extras/etc/nginx/nginx.conf
@@ -48,11 +48,23 @@ http {
                 return 302 https://$host:8443$request_uri;
         }
 
+        location /apt/main/dists {
+                proxy_pass              http://archive.ubuntu.com/ubuntu/dists/;
+                proxy_cache             DEBIDX;
+                proxy_cache_valid       5m;
+        }
+
 	location /apt/main {
                 proxy_pass              http://archive.ubuntu.com/ubuntu/;
                 proxy_cache             DEB;
                 proxy_cache_valid       1d;
 		proxy_ignore_headers    "Cache-Control" "Expires";
+        }
+
+        location /apt/security/dists {
+                proxy_pass              http://security.ubuntu.com/ubuntu/dists;
+                proxy_cache             DEBIDX;
+                proxy_cache_valid       5m;
         }
 
         location /apt/security {

--- a/extras/etc/nginx/proxy.conf
+++ b/extras/etc/nginx/proxy.conf
@@ -1,2 +1,3 @@
-proxy_cache_path /var/snap/subutai/common/cache/nginx/proxy_cache/ levels=1:2 keys_zone=DEB:10m inactive=24h max_size=1g;
+proxy_cache_path /var/snap/subutai/common/cache/nginx/proxy_cache/DEB/ levels=1:2 keys_zone=DEB:10m inactive=24h max_size=1g;
+proxy_cache_path /var/snap/subutai/common/cache/nginx/proxy_cache/DEBIDX/ levels=1:2 keys_zone=DEBIDX:10m inactive=4h max_size=100m;
 proxy_temp_path /var/snap/subutai/common/cache/nginx/proxy_tmp/ 1 2;


### PR DESCRIPTION
By separating the cache of apt indexes from deb files, we are able to shorten the valid time from a day to several minutes, this won't add a lot of load to origin server but will minimize the possibility of hash sum mismatch problem on the client side cache:

> W: Failed to fetch gzip:/var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial_main_source_Sources  Hash Sum mismatch, 
> E: Some index files failed to download. They have been ignored, or old ones used instead.

Fixes subutai-io/snap#134