### PR TITLE
Detect modprobe return code for kmod check

### DIFF
--- a/extras/bin/ovs-init-db
+++ b/extras/bin/ovs-init-db
@@ -7,10 +7,10 @@ RET_OVS=$?
 modprobe iptable_nat
 RET_IPT=$?
 
-while [ ! $RET_IPT -eq 0 ] || [ ! $RET_OVS -eq 0 ]; do
+if [ ! $RET_IPT -eq 0 ] || [ ! $RET_OVS -eq 0 ]; then
         echo "Unable to load openvswitch or iptable_nat kernel module. Please load module manually"
-        sleep 10
-done
+        exit 1
+fi
 
 sysctl -w net.ipv4.ip_forward=1
 sysctl -w net.ipv4.conf.all.forwarding=1

--- a/extras/bin/ovs-init-db
+++ b/extras/bin/ovs-init-db
@@ -7,10 +7,10 @@ RET_OVS=$?
 modprobe iptable_nat
 RET_IPT=$?
 
-if [ ! $RET_IPT -eq 0 ] || [ ! $RET_OVS -eq 0 ]; then
+while [ ! $RET_IPT -eq 0 ] || [ ! $RET_OVS -eq 0 ]; do
         echo "Unable to load openvswitch or iptable_nat kernel module. Please load module manually"
-        exit 1
-fi
+        sleep 10
+done
 
 sysctl -w net.ipv4.ip_forward=1
 sysctl -w net.ipv4.conf.all.forwarding=1

--- a/extras/bin/ovs-init-db
+++ b/extras/bin/ovs-init-db
@@ -3,11 +3,13 @@
 mkdir -p /var/run/openvswitch/
 
 modprobe openvswitch
+RET_OVS=$?
 modprobe iptable_nat
+RET_IPT=$?
 
-while [ $(lsmod | grep -c 'openvswitch\|iptable_nat') -lt 7 ]; do
-	echo "Unable to load openvswitch or iptable_nat kernel module. Please load module manually"
-	sleep 10 
+while [ ! $RET_IPT -eq 0 ] || [ ! $RET_OVS -eq 0 ]; do
+        echo "Unable to load openvswitch or iptable_nat kernel module. Please load module manually"
+        sleep 10
 done
 
 sysctl -w net.ipv4.ip_forward=1


### PR DESCRIPTION
This closes #67 which was led by counting active LKM numbers, which may lead to trouble with custom kernel builds that have some functionality built into the image.