### PR TITLE
Tweak of btrfsinit script

### DIFF
--- a/extras/bin/btrfsinit
+++ b/extras/bin/btrfsinit
@@ -27,9 +27,9 @@ if [ "$SNAP_NAME" == "" ]; then
 fi
 if $flag_force; then
 	umount $fs
-	mkfs.btrfs -f $fs
+	mkfs.btrfs -O extref,skinny-metadata -f $fs
 else
-	mkfs.btrfs $fs
+	mkfs.btrfs -O extref,skinny-metadata $fs
 fi
 
 UNIT="var-snap-$(echo ${SNAP_NAME} | sed -e "s/-/\\\x2d/g")-common-lxc.mount"

--- a/extras/bin/btrfsinit
+++ b/extras/bin/btrfsinit
@@ -1,16 +1,35 @@
 #!/bin/bash
 
+n=1
+while [ $# -gt 0 ]; do
+    case $1 in
+        -*) break;;
+        *) eval "arg_$n=\$1"; n=$(( $n + 1 )) ;;
+    esac
+    shift
+done
+
+flag_force=false
+while getopts ":f" opt; do
+    case $opt in
+        f) flag_force=true;;
+    esac
+    shift
+done
+
+fs=$arg_1$1
+
 if [ "$SNAP_NAME" == "" ]; then
 	SNAP_NAME=$(ls /snap | grep subutai | head -n1)
 	SNAP="/snap/$SNAP_NAME/current/"
 	SNAP_DATA="/var/$SNAP"
 	PATH=$PATH:$SNAP/bin/
 fi
-if [ "$2" == "-f" ]; then
-	umount $1
-	mkfs.btrfs -f $1
+if $flag_force; then
+	umount $fs
+	mkfs.btrfs -f $fs
 else
-	mkfs.btrfs $1
+	mkfs.btrfs $fs
 fi
 
 UNIT="var-snap-$(echo ${SNAP_NAME} | sed -e "s/-/\\\x2d/g")-common-lxc.mount"
@@ -23,7 +42,7 @@ echo "[Unit]
 Description = BTRFS mount
 
 [Mount]
-What = $1
+What = $fs
 Where = /var/snap/$SNAP_NAME/common/lxc
 Type = btrfs
 
@@ -31,7 +50,7 @@ Type = btrfs
 WantedBy = multi-user.target" > $DIR/$UNIT
 
 mkdir -p /var/snap/$SNAP_NAME/common/lxc
-mount $1 /var/snap/$SNAP_NAME/common/lxc
+mount $fs /var/snap/$SNAP_NAME/common/lxc
 
 systemctl daemon-reload
 systemctl start $UNIT


### PR DESCRIPTION
This PR includes two changes:

- Use getopts to allow free ordering of "-f" and device name
- Explicitly enable extref and skinny-metadata features when creating the filesystem

The first one is quite self-descriptive, this is just an improvement of interactive issue to avoid mystery failures when the arguments are called with different order.

The two btrfs features enabled here are default in recent Linux kernel/btrfs-progs, but vary in older ones, we are enabling them explicitly to make sure those features are present. Because our containers are mostly small files while having a great chance of having files COW'ed, we want these features to make metadata handling more robust.

From btrfs documentation:
- extref (default since btrfs-progs 3.12, kernel support since 3.7) increased hardlink limit per file in a directory to 65536, older kernels supported a varying number of hardlinks depending on the sum of all file name sizes that can be stored into one metadata block
- skinny-metadata (default since btrfs-progs 3.18, kernel support since 3.10) reduced-size metadata for extent references, saves a few percent of metadata