### PR TITLE
Move to classic snap

### DIFF
--- a/snapcraft.yaml.templ
+++ b/snapcraft.yaml.templ
@@ -1,7 +1,7 @@
 name: (SUBUTAI)
 version: "(SNAP_VERSION)-(SNAP_BRANCH)"
 grade: stable
-confinement: devmode
+confinement: classic
 summary: Open Source LXC orchestration tool
 description: "For more details please visit our site: https://subut.ai"
 


### PR DESCRIPTION
According to the discussion about viable options of getting snap to the Store, classic mode was chosen to be the current solution to rescue our lives. This single line change would make the snap into classic mode without problem.