### PR TITLE
Make nginx more patient to upstream, also use IP address as backup

### DIFF
--- a/extras/etc/nginx/nginx.conf
+++ b/extras/etc/nginx/nginx.conf
@@ -42,6 +42,21 @@ http {
 
         #charset koi8-r;
 
+        upstream ubuntu-archive {
+                ip_hash;
+                server archive.ubuntu.com resolve max_fails=10;
+                server us.archive.ubuntu.com resolve max_fails=10;
+                server 91.189.88.161 backup;
+                server 91.189.88.149 backup;
+        }
+
+        upstream ubuntu-security {
+                ip_hash;
+                server security.ubuntu.com resolve max_fails=10;
+                server 91.189.91.26 backup;
+                server 91.189.91.23 backup;
+        }
+
         location / {
                 try_files $uri @redirect;
         }
@@ -51,26 +66,26 @@ http {
         }
 
         location /apt/main/dists {
-                proxy_pass              http://archive.ubuntu.com/ubuntu/dists/;
+                proxy_pass              http://ubuntu-archive/ubuntu/dists/;
                 proxy_cache             DEBIDX;
                 proxy_cache_valid       5m;
         }
 
 	    location /apt/main {
-                proxy_pass              http://archive.ubuntu.com/ubuntu/;
+                proxy_pass              http://ubuntu-archive/ubuntu/;
                 proxy_cache             DEB;
                 proxy_cache_valid       1d;
 		        proxy_ignore_headers    "Cache-Control" "Expires";
         }
 
         location /apt/security/dists {
-                proxy_pass              http://security.ubuntu.com/ubuntu/dists;
+                proxy_pass              http://ubuntu-security/ubuntu/dists;
                 proxy_cache             DEBIDX;
                 proxy_cache_valid       5m;
         }
 
         location /apt/security {
-                proxy_pass              http://security.ubuntu.com/ubuntu/;
+                proxy_pass              http://ubuntu-security/ubuntu/;
                 proxy_cache             DEB;
                 proxy_cache_valid       1d;
 		        proxy_ignore_headers    "Cache-Control" "Expires";


### PR DESCRIPTION
This PR does the following thing in hope to mitigate subutai-io/snap#272

1. Setup dedicated upstream block in nginx.conf for ubuntu-archive and ubuntu-security
2. Increases max_fails for every upstream domain
3. Fallback to IP addresses when all previous servers are marked as failed.