### PR TITLE
[nginx] Put upstream out of server section

### DIFF
--- a/extras/etc/nginx/nginx.conf
+++ b/extras/etc/nginx/nginx.conf
@@ -36,26 +36,26 @@ http {
     include "/var/snap/subutai-master/current/nginx/conf.d/*.conf";
     include "/var/snap/subutai-sysnet/current/nginx/conf.d/*.conf";
 
+    upstream ubuntu-archive {
+            ip_hash;
+            server archive.ubuntu.com resolve max_fails=10;
+            server us.archive.ubuntu.com resolve max_fails=10;
+            server 91.189.88.161 backup;
+            server 91.189.88.149 backup;
+    }
+
+    upstream ubuntu-security {
+            ip_hash;
+            server security.ubuntu.com resolve max_fails=10;
+            server 91.189.91.26 backup;
+            server 91.189.91.23 backup;
+    }
+
     server {
         listen       80;
         server_name  localhost;
 
         #charset koi8-r;
-
-        upstream ubuntu-archive {
-                ip_hash;
-                server archive.ubuntu.com resolve max_fails=10;
-                server us.archive.ubuntu.com resolve max_fails=10;
-                server 91.189.88.161 backup;
-                server 91.189.88.149 backup;
-        }
-
-        upstream ubuntu-security {
-                ip_hash;
-                server security.ubuntu.com resolve max_fails=10;
-                server 91.189.91.26 backup;
-                server 91.189.91.23 backup;
-        }
 
         location / {
                 try_files $uri @redirect;


### PR DESCRIPTION
Previous configuration has compatibility issue, now moving the upstream section out of the server section, so that the conf test does not fail.