### PR TITLE
[nginx] remove unsupported feature: resolve

### DIFF
--- a/extras/etc/nginx/nginx.conf
+++ b/extras/etc/nginx/nginx.conf
@@ -38,15 +38,15 @@ http {
 
     upstream ubuntu-archive {
             ip_hash;
-            server archive.ubuntu.com resolve max_fails=10;
-            server us.archive.ubuntu.com resolve max_fails=10;
+            server archive.ubuntu.com max_fails=10;
+            server us.archive.ubuntu.com max_fails=10;
             server 91.189.88.161 backup;
             server 91.189.88.149 backup;
     }
 
     upstream ubuntu-security {
             ip_hash;
-            server security.ubuntu.com resolve max_fails=10;
+            server security.ubuntu.com max_fails=10;
             server 91.189.91.26 backup;
             server 91.189.91.23 backup;
     }


### PR DESCRIPTION
The version of nginx in snap does not support the "resolve" feature of upstream servers, hence removing.